### PR TITLE
SplashPage -> WeatherPage の遷移を修正

### DIFF
--- a/lib/features/splash/splash_page.dart
+++ b/lib/features/splash/splash_page.dart
@@ -21,7 +21,7 @@ class _SplashPageState extends State<SplashPage> with AfterLayoutMixin {
 
   Future<void> _goToWeatherPage() async {
     await Future<void>.delayed(_waitingTime);
-    if (!context.mounted) {
+    if (!mounted) {
       return;
     }
 

--- a/lib/features/splash/splash_page.dart
+++ b/lib/features/splash/splash_page.dart
@@ -27,7 +27,7 @@ class _SplashPageState extends State<SplashPage> with AfterLayoutMixin {
 
     await const WeatherRoute().push<void>(context);
 
-    unawaited(_goToWeatherPage());
+    unawaited(afterActionFrameCompletes());
   }
 
   @override

--- a/lib/utils/mixin/after_layout_mixin.dart
+++ b/lib/utils/mixin/after_layout_mixin.dart
@@ -4,14 +4,14 @@ import 'package:flutter/scheduler.dart';
 import 'package:flutter/widgets.dart';
 
 mixin AfterLayoutMixin<T extends StatefulWidget> on State<T> {
-  @protected
-  void afterLayout();
-
   @override
   void initState() {
     super.initState();
     unawaited(afterActionFrameCompletes());
   }
+
+  @protected
+  void afterLayout();
 
   @protected
   Future<void> afterActionFrameCompletes() async {

--- a/lib/utils/mixin/after_layout_mixin.dart
+++ b/lib/utils/mixin/after_layout_mixin.dart
@@ -9,10 +9,10 @@ mixin AfterLayoutMixin<T extends StatefulWidget> on State<T> {
   @override
   void initState() {
     super.initState();
-    unawaited(_afterActionFrameCompletes());
+    unawaited(afterActionFrameCompletes());
   }
 
-  Future<void> _afterActionFrameCompletes() async {
+  Future<void> afterActionFrameCompletes() async {
     await SchedulerBinding.instance.endOfFrame;
     afterLayout();
   }

--- a/lib/utils/mixin/after_layout_mixin.dart
+++ b/lib/utils/mixin/after_layout_mixin.dart
@@ -4,6 +4,7 @@ import 'package:flutter/scheduler.dart';
 import 'package:flutter/widgets.dart';
 
 mixin AfterLayoutMixin<T extends StatefulWidget> on State<T> {
+  @protected
   void afterLayout();
 
   @override
@@ -12,6 +13,7 @@ mixin AfterLayoutMixin<T extends StatefulWidget> on State<T> {
     unawaited(afterActionFrameCompletes());
   }
 
+  @protected
   Future<void> afterActionFrameCompletes() async {
     await SchedulerBinding.instance.endOfFrame;
     afterLayout();


### PR DESCRIPTION
## 課題

- AfterLayoutMixin の使用方法が間違っていたので修正
- 遅延時間を限りなく短くし、Close ボタンを高速連打するとレイアウトエラーが発生していた
  - なので現行の仕様（0.5秒の遅延）においては問題が発生していなかった
- `SchedulerBinding.instance.endOfFrame`が機能しないような実装になっていた

## 対応箇所

<!--
課題のどこに対応したか１つ１つ確認しましょう。
-->

- [x] Mixin仕様クラスで適切にメソッドを使用するように修正
- [x] `@protect` を付与

## 動作
動作自体は変わりません